### PR TITLE
Skip e2e tests gracefully when YouTube shows bot challenge

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -32,13 +32,15 @@ jobs:
       - name: Run E2E tests
         run: npm test
 
-      # Upload screenshots and diagnostics on failure
+      # Upload screenshots and diagnostics on failure or when tests were skipped
+      # (e.g. YouTube bot challenge detection saves diagnostics even on skip)
       - name: Upload failure diagnostics
-        if: failure()
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: e2e-failure-diagnostics
           path: tests/e2e/screenshots/
+          if-no-files-found: ignore
           retention-days: 14
 
       # On scheduled run failure, create or comment on a GitHub issue

--- a/tests/e2e/extension.test.js
+++ b/tests/e2e/extension.test.js
@@ -18,11 +18,22 @@ const TEST_VIDEO = TEST_VIDEOS[0];
 
 describe("YouTube Subtitle Search Extension", { timeout: 120000 }, () => {
   let driver;
+  let botBlocked = false;
+
+  function skipIfBotBlocked(ctx) {
+    if (botBlocked) {
+      ctx.skip("YouTube bot challenge detected — skipping (not an extension bug)");
+    }
+  }
 
   before(async () => {
     const extensionPath = buildExtension();
     driver = await launchFirefoxWithExtension(extensionPath);
     await openYouTubeVideo(driver, TEST_VIDEO.url);
+    if (driver._botChallengeDetected) {
+      botBlocked = true;
+      await saveDiagnostics(driver, "00-bot-challenge-primary");
+    }
   });
 
   after(async () => {
@@ -31,7 +42,8 @@ describe("YouTube Subtitle Search Extension", { timeout: 120000 }, () => {
     }
   });
 
-  it("should inject the search button into YouTube player controls", async () => {
+  it("should inject the search button into YouTube player controls", async (t) => {
+    skipIfBotBlocked(t);
     try {
       const searchBtn = await waitForElement(driver, "#subtitle-search-button", 20000);
       assert.ok(searchBtn, "Search button element should exist");
@@ -55,7 +67,8 @@ describe("YouTube Subtitle Search Extension", { timeout: 120000 }, () => {
     }
   });
 
-  it("should open the search iframe when the search button is clicked", async () => {
+  it("should open the search iframe when the search button is clicked", async (t) => {
+    skipIfBotBlocked(t);
     try {
       const searchBtn = await waitForElement(driver, "#subtitle-search-button", 10000);
       await searchBtn.click();
@@ -80,7 +93,8 @@ describe("YouTube Subtitle Search Extension", { timeout: 120000 }, () => {
     }
   });
 
-  it("should return search results when typing a known subtitle word", async () => {
+  it("should return search results when typing a known subtitle word", async (t) => {
+    skipIfBotBlocked(t);
     try {
       // Switch into the extension iframe
       await switchToExtensionIframe(driver);
@@ -125,7 +139,8 @@ describe("YouTube Subtitle Search Extension", { timeout: 120000 }, () => {
     }
   });
 
-  it("should seek the video when clicking a search result", async () => {
+  it("should seek the video when clicking a search result", async (t) => {
+    skipIfBotBlocked(t);
     try {
       // Record current video time
       const timeBefore = await driver.executeScript(
@@ -180,7 +195,8 @@ describe("YouTube Subtitle Search Extension", { timeout: 120000 }, () => {
     }
   });
 
-  it("should inject 'Copy transcript' into the three-dot menu", async () => {
+  it("should inject 'Copy transcript' into the three-dot menu", async (t) => {
+    skipIfBotBlocked(t);
     try {
       // Make sure we're on the main page
       await switchToMainPage(driver);
@@ -238,12 +254,23 @@ describe("YouTube Subtitle Search Extension", { timeout: 120000 }, () => {
 // to verify the extension works across different videos
 describe("Fallback video validation", { timeout: 120000 }, () => {
   let driver;
+  let botBlocked = false;
   const FALLBACK_VIDEO = TEST_VIDEOS[1];
+
+  function skipIfBotBlocked(ctx) {
+    if (botBlocked) {
+      ctx.skip("YouTube bot challenge detected — skipping (not an extension bug)");
+    }
+  }
 
   before(async () => {
     const extensionPath = buildExtension();
     driver = await launchFirefoxWithExtension(extensionPath);
     await openYouTubeVideo(driver, FALLBACK_VIDEO.url);
+    if (driver._botChallengeDetected) {
+      botBlocked = true;
+      await saveDiagnostics(driver, "00-bot-challenge-fallback");
+    }
   });
 
   after(async () => {
@@ -252,7 +279,8 @@ describe("Fallback video validation", { timeout: 120000 }, () => {
     }
   });
 
-  it("should inject search button on fallback video", async () => {
+  it("should inject search button on fallback video", async (t) => {
+    skipIfBotBlocked(t);
     try {
       const searchBtn = await waitForElement(driver, "#subtitle-search-button", 20000);
       assert.ok(searchBtn, "Search button should exist on fallback video");
@@ -262,7 +290,8 @@ describe("Fallback video validation", { timeout: 120000 }, () => {
     }
   });
 
-  it("should find search results on fallback video", async () => {
+  it("should find search results on fallback video", async (t) => {
+    skipIfBotBlocked(t);
     try {
       // Click search button to open iframe
       const searchBtn = await waitForElement(driver, "#subtitle-search-button", 10000);


### PR DESCRIPTION
YouTube CI runs on GitHub Actions IPs that increasingly trigger "Sign in to confirm you are not a bot" interstitials, causing all tests to fail with confusing ElementNotInteractableError / TimeoutError messages.

Changes:
- Add detectBotChallenge() to recognize bot/CAPTCHA pages in helpers.js
- Set dom.webdriver.enabled=false and a realistic user-agent to reduce detection likelihood
- openYouTubeVideo() now sets driver._botChallengeDetected flag instead of failing when a bot challenge is detected
- Each test calls t.skip() with a clear message when bot-blocked, so CI reports skipped tests instead of false failures
- CI workflow uploads diagnostics on all runs (not just failures) and no longer creates spurious GitHub issues for bot-gated runs

https://claude.ai/code/session_01TToBUjWx3DpnUXrtHS6a2o